### PR TITLE
[FIX] Broken UsersController spec: get -> post

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe UsersController, type: :controller do
 
-  describe "GET #create" do
+  describe "POST #create" do
     it "returns http success" do
-      get :create
+      post :create, user: { token: "1234abcd" }
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -49,5 +49,5 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   #Make FG methods available
-  config.inlcude FactoryGirl::Syntax::Methods
+  config.include FactoryGirl::Syntax::Methods
 end


### PR DESCRIPTION
Hi,

Here's a quickfix for your spec. I decided to push that as a Pull Request, because it seems it's just forgetfulness.
- Typo in spec/rails_helper.rb
- Fix incorrect expectation about UsersController#create responding to a
  GET request (it responds to a POST request)
