### PR TITLE
[FIX] Finding the proper App when creating an event

### DIFF
--- a/app/controllers/apps/events_controller.rb
+++ b/app/controllers/apps/events_controller.rb
@@ -3,7 +3,7 @@ module Apps
     before_action :authenticated?
 
     def create
-      app = App.find_by!(domain: :domain)
+      app = App.find(params[:app_id])
       event = app.events.build(event_params)
       if event.save
         render json: event, status: 201


### PR DESCRIPTION
There, I am using `params[:app_id]` to find the `App` I want to register an event for. That `:app_id` is reliable, because it comes from the url itself (see routes: http://localhost:3001/apps/:app_id/events) and it will only be used to _find_ something in the database, not for updating content.

The data describing the event to create must be filtered using StrongParameters (`require`/`permit`), because that has been provided as the payload of the POST request and thus should not be blindly whitelisted as a whole. One may also add a validation layer on the `Event` model to further constrain the creation/edit operations, ensuring the content of the whitelisted keys is OK to go with.
